### PR TITLE
revert back to errorMode nested after request assertion

### DIFF
--- a/lib/unexpectedMxhr.js
+++ b/lib/unexpectedMxhr.js
@@ -208,7 +208,8 @@ module.exports = {
                                 var assertionExchange = new messy.HttpExchange({request: mockRequest});
 
                                 expect.errorMode = 'default';
-                                return expect(assertionExchange, 'to satisfy', {request: expectedRequestProperties});
+                                return expect(assertionExchange, 'to satisfy', {request: expectedRequestProperties})
+                                    .finally(function () { expect.errorMode = 'nested'; });
                             }).then(function () {
                                 var mockResponse = createMockResponse(requestDescription && requestDescription.response);
 

--- a/test/unexpectedMxhr.browser.js
+++ b/test/unexpectedMxhr.browser.js
@@ -255,14 +255,15 @@ describe('unexpectedMxhr', function () {
             'when rejected to have message',
             "expected { url: 'PUT /' }\n" +
             "with xhr mocked out { request: { method: 'PUT' }, response: 202 } to yield response 201\n" +
-            '\n' +
-            'PUT / HTTP/1.1\n' +
-            'Content-Length: 0\n' +
-            '\n' +
-            'HTTP/1.1 202 Accepted // should be 201 Created\n' +
-            '                      //\n' +
-            '                      // -HTTP/1.1 202 Accepted\n' +
-            '                      // +HTTP/1.1 201 Created\n'
+            "  expected { url: 'PUT /' } to yield response 201\n" +
+            "\n" +
+            "  PUT / HTTP/1.1\n" +
+            "  Content-Length: 0\n" +
+            "\n" +
+            "  HTTP/1.1 202 Accepted // should be 201 Created\n" +
+            "                        //\n" +
+            "                        // -HTTP/1.1 202 Accepted\n" +
+            "                        // +HTTP/1.1 201 Created\n"
         );
     });
 


### PR DESCRIPTION
I had a test which had it's diff eaten because error mode wasn't set back to nested. Doing this fix had the side effect of nesting in the diff from unexpected-http though, but other than that, it seems to work the same.